### PR TITLE
Implement to_aa_notation conversion

### DIFF
--- a/Test.gd
+++ b/Test.gd
@@ -207,6 +207,25 @@ func test_rsa():
 
 	print("RSA test passed!")
 
+func test_aa_notation():
+	const expect_postfix := [
+		"k", "m", "b", "t", 
+		"aa", "ab", "ac", "ad", "ae", "af", 
+		"ag", "ah", "ai", "aj", "ak", "al", 
+		"am", "an", "ao", "ap", "aq", "ar",
+		"as", "at", "au", "av", "aw", "ax",
+		"ay", "az", "ba", "bb", "bc", "bd"
+	]
+	
+	var thousands := 3
+	for postfix in expect_postfix:
+		var big = BigCat.BigNumber.from_int(10)
+		big = big.power_uint(thousands)
+		var res_postfix := big.to_aa_notation(0).substr(1)
+		assert(postfix == res_postfix)
+		thousands += 3
+	
+
 func _ready():
 	test_int_conversion()
 	test_string_conversion()
@@ -218,3 +237,4 @@ func _ready():
 	test_sqrt()
 	test_power_modulo()
 	test_rsa()
+	test_aa_notation()


### PR DESCRIPTION
This pr adds support for converting the BigNumber class to AA notation eg. 40ab, 32.12ba... I tried to follow your code style and wrote a test case. I believe the AA notation is vital to any BigNumber class due to their usecases within idle games for which BigNumber's are often a requirement.

Read more: https://web.archive.org/web/20230531113604/https://gram.gs/gramlog/formatting-big-numbers-aa-notation/ 